### PR TITLE
Add interactive takeoff web UI

### DIFF
--- a/construction_takeoff/README.md
+++ b/construction_takeoff/README.md
@@ -1,0 +1,83 @@
+# Construction Takeoff Automation
+
+This project provides a Python-based prototype for automating construction takeoffs with a "human-in-the-loop" workflow. It ingests machine-readable drawing exports, performs trade-specific quantity takeoffs, estimates material and labor costs, and exports a spreadsheet-friendly CSV summary for review.
+
+The tool is intended as a starting point for a richer desktop or web product. It focuses on extensibility and repeatability rather than perfect accuracy on raw PDF drawings; the system expects vector or BIM-derived JSON data extracted from the drawings. Estimators are modular so that trade experts can refine the logic or plug in vendor pricing feeds.
+
+## Features
+
+- Command line interface for running takeoffs per trade.
+- Drawing analyzer that aggregates geometry and metadata from JSON exports.
+- Pluggable estimators for each trade (concrete example provided).
+- Labor and material costing with configuration-driven production rates.
+- Human-in-the-loop checkpoints to flag assumptions and require acknowledgement.
+- Spreadsheet (CSV) exporter that is compatible with Excel/Google Sheets.
+
+## Usage
+
+```
+PYTHONPATH=construction_takeoff python -m takeoff.cli --trade concrete --input /path/to/drawings --output estimate.csv
+```
+
+1. Export your construction drawings into JSON using the provided schema (see `docs/sample_drawing.json`).
+2. Run the CLI with the trade you want to estimate.
+3. Review the generated CSV alongside the human-review notes in the console.
+4. Adjust assumptions as needed and rerun.
+
+## Web Experience
+
+An interactive web workspace is available for teams that prefer a visual workflow and richer UX.
+
+### Install UI dependencies
+
+```
+pip install fastapi uvicorn jinja2 python-multipart
+```
+
+### Launch the interface
+
+```
+PYTHONPATH=construction_takeoff uvicorn takeoff.webapp.app:create_app --reload
+```
+
+Navigate to [http://localhost:8000](http://localhost:8000) to access the UI. From there you can:
+
+- Pick a trade from the live registry.
+- Drag and drop JSON or ZIP exports of your drawing takeoff data.
+- Review an instant dashboard showing material, labor, total costs, and labor hours.
+- Inspect human-in-the-loop checkpoints before publishing an estimate.
+- Download the spreadsheet-ready CSV directly from the browser.
+
+## Project Layout
+
+- `takeoff/cli.py` – Command-line entry point.
+- `takeoff/project.py` – Coordinates parsing, estimation, human review, and exporting.
+- `takeoff/drawings.py` – Data model for drawings and utilities to load them from disk or archives.
+- `takeoff/estimators/` – Trade-specific estimators implementing material and labor logic.
+- `takeoff/exporters/spreadsheet.py` – CSV export utility.
+- `takeoff/human_review.py` – Workflow helpers for interactive checkpoints.
+- `takeoff/service.py` – Programmatic helpers used by both the CLI and UI.
+- `takeoff/webapp/` – FastAPI application delivering the interactive UX.
+
+## Extending to Other Trades
+
+Add a new estimator in `takeoff/estimators/your_trade.py` inheriting from `BaseTradeEstimator`. Register it in `TRADE_REGISTRY` inside `takeoff/estimators/__init__.py`. Each estimator can:
+
+- Define what drawing element categories it cares about.
+- Provide unit conversions and waste factors.
+- Supply production rates to translate quantities into labor hours.
+- Reference vendor pricing files or external APIs.
+
+## Human-in-the-loop Design
+
+The CLI prints out a checklist of assumptions and allows the reviewer to accept or reject them. In a full product this would be replaced by a UI with markup back to the drawing set.
+
+## Future Enhancements
+
+- Native PDF/BIM parsing layer.
+- Versioned pricing database with supplier integrations.
+- Rich UI for reviewing marked-up takeoffs.
+- Collaboration tools for multi-trade coordination.
+- Cloud deployment for scale and audit trails.
+
+This prototype demonstrates the architecture and core mechanics for an automated takeoff assistant similar to "Cursor" but tailored to construction workflows.

--- a/construction_takeoff/docs/sample_drawing.json
+++ b/construction_takeoff/docs/sample_drawing.json
@@ -1,0 +1,37 @@
+{
+  "project": {
+    "name": "Example Office Tower",
+    "level": "P1",
+    "scale": "1/8\" = 1'-0"
+  },
+  "elements": [
+    {
+      "id": "slab-01",
+      "trade": "concrete",
+      "category": "slab",
+      "geometry": {
+        "area_sqft": 1200.0,
+        "thickness_in": 6
+      }
+    },
+    {
+      "id": "wall-01",
+      "trade": "concrete",
+      "category": "wall",
+      "geometry": {
+        "length_ft": 40,
+        "height_ft": 12,
+        "thickness_in": 8
+      }
+    },
+    {
+      "id": "pier-01",
+      "trade": "concrete",
+      "category": "pier",
+      "geometry": {
+        "diameter_in": 18,
+        "depth_ft": 25
+      }
+    }
+  ]
+}

--- a/construction_takeoff/takeoff/__init__.py
+++ b/construction_takeoff/takeoff/__init__.py
@@ -1,0 +1,6 @@
+"""Construction takeoff automation package."""
+
+from .project import TakeoffConfig, TakeoffProject
+from .service import TakeoffRun, run_trade_takeoff
+
+__all__ = ["TakeoffConfig", "TakeoffProject", "TakeoffRun", "run_trade_takeoff"]

--- a/construction_takeoff/takeoff/__main__.py
+++ b/construction_takeoff/takeoff/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running `python -m takeoff`."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/construction_takeoff/takeoff/cli.py
+++ b/construction_takeoff/takeoff/cli.py
@@ -1,0 +1,34 @@
+"""Command-line interface for the construction takeoff tool."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+from .project import TakeoffConfig, TakeoffProject
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Automated construction takeoff assistant")
+    parser.add_argument("--trade", required=True, help="Trade to estimate (e.g. concrete, roofing)")
+    parser.add_argument("--input", required=True, help="Path to directory or zip containing drawing JSON exports")
+    parser.add_argument("--output", required=True, help="Path to write the resulting CSV estimate")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config = TakeoffConfig(
+        trade=args.trade,
+        input_path=pathlib.Path(args.input).expanduser().resolve(),
+        output_path=pathlib.Path(args.output).expanduser().resolve(),
+    )
+
+    project = TakeoffProject(config)
+    project.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/construction_takeoff/takeoff/drawings.py
+++ b/construction_takeoff/takeoff/drawings.py
@@ -1,0 +1,111 @@
+"""Utilities for loading and representing drawing data for takeoffs."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import zipfile
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass
+class DrawingElement:
+    """Single element extracted from a drawing set."""
+
+    id: str
+    trade: str
+    category: str
+    geometry: Dict[str, float]
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Drawing:
+    """Represents a single drawing or level within the project."""
+
+    name: str
+    level: Optional[str]
+    scale: Optional[str]
+    elements: List[DrawingElement]
+
+
+class DrawingLoader:
+    """Load drawing data from a directory or zip archive.
+
+    The loader expects each drawing export to be a JSON file following the
+    schema illustrated in ``docs/sample_drawing.json``. All numeric values
+    should be expressed in imperial units to align with the estimation logic.
+    """
+
+    def __init__(self, input_path: pathlib.Path) -> None:
+        self.input_path = input_path
+
+    def load(self) -> Iterable[Drawing]:
+        if self.input_path.is_dir():
+            yield from self._load_from_directory(self.input_path)
+        elif zipfile.is_zipfile(self.input_path):
+            yield from self._load_from_zip(self.input_path)
+        else:
+            raise ValueError(
+                f"Unsupported drawing input: {self.input_path}. Expected directory or zip archive."
+            )
+
+    def _load_from_directory(self, directory: pathlib.Path) -> Iterable[Drawing]:
+        for json_path in sorted(directory.glob("*.json")):
+            yield self._load_single(json_path.read_text(), source=str(json_path))
+
+    def _load_from_zip(self, archive_path: pathlib.Path) -> Iterable[Drawing]:
+        with zipfile.ZipFile(archive_path) as archive:
+            for name in sorted(archive.namelist()):
+                if name.lower().endswith(".json"):
+                    with archive.open(name) as fh:
+                        payload = fh.read().decode("utf-8")
+                        yield self._load_single(payload, source=f"{archive_path}:{name}")
+
+    def _load_single(self, payload: str, *, source: str) -> Drawing:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Failed to parse drawing JSON from {source}: {exc}") from exc
+
+        project_info = data.get("project", {})
+        elements = [self._parse_element(item, source=source) for item in data.get("elements", [])]
+        return Drawing(
+            name=project_info.get("name", pathlib.Path(source).stem),
+            level=project_info.get("level"),
+            scale=project_info.get("scale"),
+            elements=elements,
+        )
+
+    def _parse_element(self, item: Dict, *, source: str) -> DrawingElement:
+        required_fields = {"id", "trade", "category", "geometry"}
+        missing = required_fields - item.keys()
+        if missing:
+            raise ValueError(f"Element missing fields {missing} in {source}")
+
+        geometry = item["geometry"]
+        if not isinstance(geometry, dict):
+            raise ValueError(f"Element geometry must be a dict in {source}: {item}")
+
+        metadata = {
+            key: value
+            for key, value in item.items()
+            if key not in {"id", "trade", "category", "geometry"}
+        }
+
+        return DrawingElement(
+            id=str(item["id"]),
+            trade=str(item["trade"]).lower(),
+            category=str(item["category"]).lower(),
+            geometry={k: float(v) for k, v in geometry.items()},
+            metadata=metadata,
+        )
+
+
+def group_elements_by_trade(drawings: Iterable[Drawing]) -> Dict[str, List[DrawingElement]]:
+    grouped: Dict[str, List[DrawingElement]] = {}
+    for drawing in drawings:
+        for element in drawing.elements:
+            grouped.setdefault(element.trade, []).append(element)
+    return grouped

--- a/construction_takeoff/takeoff/estimators/__init__.py
+++ b/construction_takeoff/takeoff/estimators/__init__.py
@@ -1,0 +1,14 @@
+"""Trade estimator registry."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import BaseTradeEstimator
+from .concrete import ConcreteEstimator
+
+TRADE_REGISTRY: Dict[str, Type[BaseTradeEstimator]] = {
+    ConcreteEstimator.trade_name: ConcreteEstimator,
+}
+
+__all__ = ["BaseTradeEstimator", "ConcreteEstimator", "TRADE_REGISTRY"]

--- a/construction_takeoff/takeoff/estimators/base.py
+++ b/construction_takeoff/takeoff/estimators/base.py
@@ -1,0 +1,60 @@
+"""Base classes and utilities for trade estimators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+from ..drawings import DrawingElement
+from ..human_review import ReviewChecklist
+
+
+@dataclass
+class TakeoffLineItem:
+    """Row in the resulting estimate."""
+
+    description: str
+    quantity: float
+    unit: str
+    material_unit_cost: float
+    labor_hours_per_unit: float
+    labor_rate_per_hour: float
+
+    @property
+    def material_cost(self) -> float:
+        return self.quantity * self.material_unit_cost
+
+    @property
+    def labor_hours(self) -> float:
+        return self.quantity * self.labor_hours_per_unit
+
+    @property
+    def labor_cost(self) -> float:
+        return self.labor_hours * self.labor_rate_per_hour
+
+
+@dataclass
+class TakeoffResult:
+    """Complete result of an estimator."""
+
+    line_items: List[TakeoffLineItem]
+    summary: Dict[str, float]
+
+
+class BaseTradeEstimator:
+    """Common interface for all trade estimators."""
+
+    trade_name: str
+
+    def __init__(self, *, review: ReviewChecklist) -> None:
+        self.review = review
+
+    def filter_elements(self, elements: Iterable[DrawingElement]) -> List[DrawingElement]:
+        return [element for element in elements if element.trade == self.trade_name]
+
+    def run(self, elements: Iterable[DrawingElement]) -> TakeoffResult:
+        trade_elements = self.filter_elements(elements)
+        return self.estimate(trade_elements)
+
+    def estimate(self, elements: Iterable[DrawingElement]) -> TakeoffResult:
+        raise NotImplementedError

--- a/construction_takeoff/takeoff/estimators/concrete.py
+++ b/construction_takeoff/takeoff/estimators/concrete.py
@@ -1,0 +1,177 @@
+"""Concrete trade estimator implementation."""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, List
+
+from .base import BaseTradeEstimator, TakeoffLineItem, TakeoffResult
+from ..drawings import DrawingElement
+from ..human_review import ReviewChecklist
+
+
+class ConcreteEstimator(BaseTradeEstimator):
+    trade_name = "concrete"
+
+    def __init__(self, *, review: ReviewChecklist) -> None:
+        super().__init__(review=review)
+        # Default pricing/production rates; in production these could be loaded from a DB.
+        self.material_prices = {
+            "ready_mix_cy": 135.0,  # $/cubic yard
+            "rebar_lb": 0.75,
+            "formwork_sf": 4.5,
+        }
+        self.labor_rates = {
+            "concrete_crew": 65.0,  # $/labor hour
+        }
+        self.production_rates = {
+            "place_finish_cy_per_hour": 8.0,
+            "rebar_lb_per_hour": 120.0,
+            "formwork_sf_per_hour": 40.0,
+        }
+
+    def estimate(self, elements: Iterable[DrawingElement]) -> TakeoffResult:
+        line_items: List[TakeoffLineItem] = []
+        summary: Dict[str, float] = {
+            "concrete_cy": 0.0,
+            "rebar_lb": 0.0,
+            "formwork_sf": 0.0,
+            "labor_hours": 0.0,
+            "material_cost": 0.0,
+            "labor_cost": 0.0,
+        }
+
+        for element in elements:
+            if element.category == "slab":
+                cy = self._slab_volume_cy(element)
+                formwork = element.geometry.get("area_sqft", 0.0)
+                rebar = cy * 250  # lbs per cubic yard (simplified assumption)
+                line_items.extend(
+                    [
+                        self._line_item(
+                            description=f"Concrete slab {element.id}",
+                            quantity=cy,
+                            unit="cy",
+                            material_price=self.material_prices["ready_mix_cy"],
+                            production_rate=self.production_rates["place_finish_cy_per_hour"],
+                        ),
+                        self._line_item(
+                            description=f"Rebar for slab {element.id}",
+                            quantity=rebar,
+                            unit="lb",
+                            material_price=self.material_prices["rebar_lb"],
+                            production_rate=self.production_rates["rebar_lb_per_hour"],
+                        ),
+                        self._line_item(
+                            description=f"Slab formwork {element.id}",
+                            quantity=formwork,
+                            unit="sf",
+                            material_price=self.material_prices["formwork_sf"],
+                            production_rate=self.production_rates["formwork_sf_per_hour"],
+                        ),
+                    ]
+                )
+                summary["concrete_cy"] += cy
+                summary["rebar_lb"] += rebar
+                summary["formwork_sf"] += formwork
+
+            elif element.category == "wall":
+                cy = self._wall_volume_cy(element)
+                formwork = element.geometry.get("length_ft", 0.0) * element.geometry.get("height_ft", 0.0) * 2
+                rebar = cy * 180
+                line_items.extend(
+                    [
+                        self._line_item(
+                            description=f"Concrete wall {element.id}",
+                            quantity=cy,
+                            unit="cy",
+                            material_price=self.material_prices["ready_mix_cy"],
+                            production_rate=self.production_rates["place_finish_cy_per_hour"],
+                        ),
+                        self._line_item(
+                            description=f"Rebar for wall {element.id}",
+                            quantity=rebar,
+                            unit="lb",
+                            material_price=self.material_prices["rebar_lb"],
+                            production_rate=self.production_rates["rebar_lb_per_hour"],
+                        ),
+                        self._line_item(
+                            description=f"Wall formwork {element.id}",
+                            quantity=formwork,
+                            unit="sf",
+                            material_price=self.material_prices["formwork_sf"],
+                            production_rate=self.production_rates["formwork_sf_per_hour"],
+                        ),
+                    ]
+                )
+                summary["concrete_cy"] += cy
+                summary["rebar_lb"] += rebar
+                summary["formwork_sf"] += formwork
+
+            elif element.category == "pier":
+                cy = self._pier_volume_cy(element)
+                rebar = cy * 120
+                line_items.extend(
+                    [
+                        self._line_item(
+                            description=f"Concrete pier {element.id}",
+                            quantity=cy,
+                            unit="cy",
+                            material_price=self.material_prices["ready_mix_cy"],
+                            production_rate=self.production_rates["place_finish_cy_per_hour"],
+                        ),
+                        self._line_item(
+                            description=f"Rebar for pier {element.id}",
+                            quantity=rebar,
+                            unit="lb",
+                            material_price=self.material_prices["rebar_lb"],
+                            production_rate=self.production_rates["rebar_lb_per_hour"],
+                        ),
+                    ]
+                )
+                summary["concrete_cy"] += cy
+                summary["rebar_lb"] += rebar
+
+            else:
+                self.review.add(
+                    f"Concrete estimator encountered unsupported category '{element.category}' for element {element.id}.",
+                    severity="warning",
+                )
+
+        for item in line_items:
+            summary["material_cost"] += item.material_cost
+            summary["labor_hours"] += item.labor_hours
+            summary["labor_cost"] += item.labor_cost
+
+        return TakeoffResult(line_items=line_items, summary=summary)
+
+    # --- Helpers -----------------------------------------------------------------
+
+    def _line_item(self, *, description: str, quantity: float, unit: str, material_price: float, production_rate: float) -> TakeoffLineItem:
+        labor_rate = self.labor_rates["concrete_crew"]
+        labor_hours_per_unit = 1 / production_rate if production_rate else 0.0
+        return TakeoffLineItem(
+            description=description,
+            quantity=quantity,
+            unit=unit,
+            material_unit_cost=material_price,
+            labor_hours_per_unit=labor_hours_per_unit,
+            labor_rate_per_hour=labor_rate,
+        )
+
+    def _slab_volume_cy(self, element: DrawingElement) -> float:
+        area = element.geometry.get("area_sqft", 0.0)
+        thickness = element.geometry.get("thickness_in", 0.0)
+        return area * thickness / 12 / 27
+
+    def _wall_volume_cy(self, element: DrawingElement) -> float:
+        length = element.geometry.get("length_ft", 0.0)
+        height = element.geometry.get("height_ft", 0.0)
+        thickness = element.geometry.get("thickness_in", 0.0)
+        return length * height * thickness / 12 / 27
+
+    def _pier_volume_cy(self, element: DrawingElement) -> float:
+        diameter = element.geometry.get("diameter_in", 0.0)
+        depth = element.geometry.get("depth_ft", 0.0)
+        radius_ft = (diameter / 12) / 2
+        return math.pi * radius_ft * radius_ft * depth / 27

--- a/construction_takeoff/takeoff/exporters/spreadsheet.py
+++ b/construction_takeoff/takeoff/exporters/spreadsheet.py
@@ -1,0 +1,75 @@
+"""Spreadsheet export utilities."""
+
+from __future__ import annotations
+
+import csv
+import io
+import pathlib
+from typing import Any, TextIO
+
+from ..estimators.base import TakeoffResult
+
+
+class SpreadsheetExporter:
+    """Export a takeoff result to CSV compatible with spreadsheets."""
+
+    def __init__(self, output_path: pathlib.Path | TextIO) -> None:
+        self.output_path = output_path
+
+    def export(self, result: TakeoffResult) -> None:
+        writer, handle = _writer_for_output(self.output_path)
+        _write_rows(writer, result)
+        if handle is not None:
+            handle.close()
+
+
+def render_csv(result: TakeoffResult) -> str:
+    """Return the CSV representation of a takeoff result as a string."""
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    _write_rows(writer, result)
+    return buffer.getvalue()
+
+
+def _writer_for_output(output: pathlib.Path | TextIO) -> tuple[Any, TextIO | None]:
+    if isinstance(output, pathlib.Path):
+        handle = output.open("w", newline="")
+        writer = csv.writer(handle)
+        return writer, handle
+
+    writer = csv.writer(output)
+    return writer, None
+
+
+def _write_rows(writer: Any, result: TakeoffResult) -> None:
+        header = [
+            "Description",
+            "Quantity",
+            "Unit",
+            "Material Unit Cost",
+            "Material Cost",
+            "Labor Hours",
+            "Labor Rate ($/hr)",
+            "Labor Cost",
+        ]
+
+        writer.writerow(header)
+        for item in result.line_items:
+            writer.writerow(
+                [
+                    item.description,
+                    round(item.quantity, 4),
+                    item.unit,
+                    round(item.material_unit_cost, 2),
+                    round(item.material_cost, 2),
+                    round(item.labor_hours, 2),
+                    round(item.labor_rate_per_hour, 2),
+                    round(item.labor_cost, 2),
+                ]
+            )
+
+        writer.writerow([])
+        writer.writerow(["Summary", "Value"])
+        for key, value in result.summary.items():
+            writer.writerow([key, round(value, 2)])

--- a/construction_takeoff/takeoff/human_review.py
+++ b/construction_takeoff/takeoff/human_review.py
@@ -1,0 +1,41 @@
+"""Human-in-the-loop helpers for the takeoff workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class ReviewItem:
+    """An assumption or decision that should be confirmed by a human."""
+
+    message: str
+    severity: str = "info"  # Could be "info", "warning", or "critical".
+
+
+class ReviewChecklist:
+    """Container used to accumulate review items during estimation."""
+
+    def __init__(self) -> None:
+        self._items: List[ReviewItem] = []
+
+    def add(self, message: str, severity: str = "info") -> None:
+        self._items.append(ReviewItem(message=message, severity=severity))
+
+    def extend(self, items: Iterable[ReviewItem]) -> None:
+        for item in items:
+            self.add(item.message, item.severity)
+
+    @property
+    def items(self) -> List[ReviewItem]:
+        return list(self._items)
+
+    def summarize(self) -> str:
+        if not self._items:
+            return "No human review items."
+
+        lines = ["Human review required for the following items:"]
+        for idx, item in enumerate(self._items, start=1):
+            lines.append(f"  {idx}. [{item.severity.upper()}] {item.message}")
+        return "\n".join(lines)

--- a/construction_takeoff/takeoff/project.py
+++ b/construction_takeoff/takeoff/project.py
@@ -1,0 +1,34 @@
+"""Project orchestration for construction takeoffs."""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+
+from .human_review import ReviewChecklist
+from .exporters.spreadsheet import SpreadsheetExporter
+from .service import run_trade_takeoff
+
+
+@dataclass
+class TakeoffConfig:
+    trade: str
+    input_path: pathlib.Path
+    output_path: pathlib.Path
+
+
+class TakeoffProject:
+    """High-level interface for executing a takeoff."""
+
+    def __init__(self, config: TakeoffConfig) -> None:
+        self.config = config
+        self.review = ReviewChecklist()
+
+    def run(self) -> None:
+        run = run_trade_takeoff(self.config.trade, self.config.input_path, review=self.review)
+
+        exporter = SpreadsheetExporter(self.config.output_path)
+        exporter.export(run.result)
+
+        print(self.review.summarize())
+        print(f"Estimate exported to {self.config.output_path}")

--- a/construction_takeoff/takeoff/service.py
+++ b/construction_takeoff/takeoff/service.py
@@ -1,0 +1,61 @@
+"""High-level helpers for running trade takeoffs programmatically."""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+
+from .drawings import DrawingLoader, group_elements_by_trade
+from .estimators import TRADE_REGISTRY, BaseTradeEstimator
+from .estimators.base import TakeoffResult
+from .human_review import ReviewChecklist
+
+
+@dataclass
+class TakeoffRun:
+    """Container describing the result of a takeoff execution."""
+
+    result: TakeoffResult
+    review: ReviewChecklist
+    trade: str
+    drawing_count: int
+    element_count: int
+
+
+def run_trade_takeoff(
+    trade: str,
+    input_path: pathlib.Path,
+    *,
+    review: ReviewChecklist | None = None,
+) -> TakeoffRun:
+    """Execute a trade takeoff and return structured results."""
+
+    drawings = list(DrawingLoader(input_path).load())
+    grouped = group_elements_by_trade(drawings)
+
+    trade_key = trade.lower()
+    if trade_key not in TRADE_REGISTRY:
+        available = ", ".join(sorted(TRADE_REGISTRY))
+        raise ValueError(f"Unsupported trade '{trade}'. Available trades: {available}")
+
+    review = review or ReviewChecklist()
+
+    estimator_cls: type[BaseTradeEstimator] = TRADE_REGISTRY[trade_key]
+    estimator = estimator_cls(review=review)
+
+    elements = grouped.get(trade_key, [])
+    if not elements:
+        review.add(
+            f"No drawing elements found for trade '{trade}'. Upload a data set that includes {trade_key} items.",
+            severity="warning",
+        )
+
+    result = estimator.run(elements)
+
+    return TakeoffRun(
+        result=result,
+        review=review,
+        trade=trade_key,
+        drawing_count=len(drawings),
+        element_count=len(elements),
+    )

--- a/construction_takeoff/takeoff/webapp/__init__.py
+++ b/construction_takeoff/takeoff/webapp/__init__.py
@@ -1,0 +1,5 @@
+"""Web application for the construction takeoff assistant."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/construction_takeoff/takeoff/webapp/__main__.py
+++ b/construction_takeoff/takeoff/webapp/__main__.py
@@ -1,0 +1,19 @@
+"""Entry point for running the takeoff web application."""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+from .app import create_app
+
+
+def main() -> None:
+    host = os.environ.get("TAKEOFF_HOST", "0.0.0.0")
+    port = int(os.environ.get("TAKEOFF_PORT", "8000"))
+    uvicorn.run(create_app(), host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/construction_takeoff/takeoff/webapp/app.py
+++ b/construction_takeoff/takeoff/webapp/app.py
@@ -1,0 +1,129 @@
+"""FastAPI application powering the takeoff UI."""
+
+from __future__ import annotations
+
+import pathlib
+from tempfile import TemporaryDirectory
+from typing import Dict, List
+
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from ..estimators import TRADE_REGISTRY
+from ..exporters.spreadsheet import render_csv
+from ..service import run_trade_takeoff
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    app = FastAPI(title="Construction Takeoff Assistant", version="0.2.0")
+    base_dir = pathlib.Path(__file__).parent
+    templates = Jinja2Templates(directory=str(base_dir / "templates"))
+    app.mount("/static", StaticFiles(directory=str(base_dir / "static")), name="static")
+
+    trade_options = sorted(TRADE_REGISTRY.keys())
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse("index.html", {"request": request, "trades": trade_options})
+
+    @app.get("/api/trades")
+    async def list_trades() -> Dict[str, List[str]]:
+        return {"trades": trade_options}
+
+    @app.get("/api/health")
+    async def healthcheck() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/api/takeoff")
+    async def perform_takeoff(trade: str = Form(...), drawing: UploadFile = File(...)) -> JSONResponse:
+        if not drawing.filename:
+            raise HTTPException(status_code=400, detail="Please upload a JSON export or ZIP archive of drawings.")
+
+        suffix = pathlib.Path(drawing.filename).suffix.lower()
+        if suffix not in {".json", ".zip"}:
+            raise HTTPException(status_code=400, detail="Unsupported file type. Upload a .json or .zip export.")
+
+        try:
+            with TemporaryDirectory() as tmp:
+                temp_dir = pathlib.Path(tmp)
+                input_path = await _persist_upload(drawing, temp_dir)
+                run = run_trade_takeoff(trade, input_path)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:  # pragma: no cover - defensive logging surface
+            raise HTTPException(status_code=500, detail="Failed to process takeoff.") from exc
+
+        csv_payload = render_csv(run.result)
+
+        material_cost = run.result.summary.get("material_cost", 0.0)
+        labor_cost = run.result.summary.get("labor_cost", 0.0)
+        total_cost = material_cost + labor_cost
+
+        response = {
+            "trade": run.trade,
+            "trade_label": _format_trade_label(run.trade),
+            "drawing_count": run.drawing_count,
+            "element_count": run.element_count,
+            "line_item_count": len(run.result.line_items),
+            "line_items": [
+                {
+                    "description": item.description,
+                    "quantity": item.quantity,
+                    "unit": item.unit,
+                    "material_unit_cost": item.material_unit_cost,
+                    "material_cost": item.material_cost,
+                    "labor_hours": item.labor_hours,
+                    "labor_rate_per_hour": item.labor_rate_per_hour,
+                    "labor_cost": item.labor_cost,
+                }
+                for item in run.result.line_items
+            ],
+            "summary": run.result.summary,
+            "metrics": {
+                "material_cost": material_cost,
+                "labor_cost": labor_cost,
+                "total_cost": total_cost,
+                "labor_hours": run.result.summary.get("labor_hours", 0.0),
+            },
+            "review": [
+                {"message": item.message, "severity": item.severity}
+                for item in run.review.items
+            ],
+            "review_summary": run.review.summarize(),
+            "csv": csv_payload,
+        }
+
+        return JSONResponse(response)
+
+    return app
+
+
+async def _persist_upload(upload: UploadFile, temp_dir: pathlib.Path) -> pathlib.Path:
+    """Persist the uploaded drawing file to a temporary location."""
+
+    payload = await upload.read()
+    if not payload:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty.")
+
+    filename = pathlib.Path(upload.filename or "drawings")
+    suffix = filename.suffix.lower()
+
+    if suffix == ".json":
+        target_dir = temp_dir / "input"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / filename.name).write_bytes(payload)
+        await upload.close()
+        return target_dir
+
+    target_path = temp_dir / filename.name
+    target_path.write_bytes(payload)
+    await upload.close()
+    return target_path
+
+
+def _format_trade_label(trade_key: str) -> str:
+    return trade_key.replace("_", " ").title()

--- a/construction_takeoff/takeoff/webapp/static/app.js
+++ b/construction_takeoff/takeoff/webapp/static/app.js
@@ -1,0 +1,290 @@
+const form = document.getElementById('takeoff-form');
+const tradeSelect = document.getElementById('trade');
+const dropZone = document.getElementById('drop-zone');
+const fileInput = document.getElementById('drawing-file');
+const dropZoneTitle = document.getElementById('drop-zone-title');
+const dropZoneSubtitle = document.getElementById('drop-zone-subtitle');
+const loadingState = document.getElementById('loading-state');
+const resultsSection = document.getElementById('results');
+const errorBanner = document.getElementById('error-banner');
+const downloadBtn = document.getElementById('download-btn');
+const lineItemsBody = document.getElementById('line-items');
+const reviewList = document.getElementById('review-items');
+const reviewEmpty = document.getElementById('review-empty');
+const metaDrawings = document.getElementById('meta-drawings');
+const metaElements = document.getElementById('meta-elements');
+const metaLines = document.getElementById('meta-lines');
+const summaryMaterial = document.getElementById('summary-material-cost');
+const summaryLabor = document.getElementById('summary-labor-cost');
+const summaryTotal = document.getElementById('summary-total-cost');
+const summaryHours = document.getElementById('summary-labor-hours');
+const heroMaterial = document.getElementById('hero-material-cost');
+const heroLabor = document.getElementById('hero-labor-cost');
+const heroTotal = document.getElementById('hero-total-cost');
+const heroReview = document.getElementById('hero-review-summary');
+
+let downloadUrl = null;
+
+disableDownload();
+
+function disableDownload() {
+  if (downloadUrl) {
+    URL.revokeObjectURL(downloadUrl);
+    downloadUrl = null;
+  }
+  downloadBtn.href = '#';
+  downloadBtn.classList.add('pointer-events-none', 'opacity-40');
+  downloadBtn.setAttribute('aria-disabled', 'true');
+}
+
+function enableDownload(csv, tradeLabel) {
+  if (downloadUrl) {
+    URL.revokeObjectURL(downloadUrl);
+  }
+  const blob = new Blob([csv], { type: 'text/csv' });
+  downloadUrl = URL.createObjectURL(blob);
+  downloadBtn.href = downloadUrl;
+  downloadBtn.download = `${tradeLabel.toLowerCase().replace(/\s+/g, '-')}-estimate.csv`;
+  downloadBtn.classList.remove('pointer-events-none', 'opacity-40');
+  downloadBtn.setAttribute('aria-disabled', 'false');
+}
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+  }).format(value ?? 0);
+}
+
+function formatNumber(value, decimals = 2) {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(value ?? 0);
+}
+
+function resetDropzone() {
+  dropZoneTitle.textContent = 'Drag & drop files here';
+  dropZoneSubtitle.textContent = 'JSON or ZIP exports up to 25MB.';
+}
+
+function updateDropzone(file) {
+  if (!file) {
+    resetDropzone();
+    return;
+  }
+  const sizeMb = file.size ? (file.size / (1024 * 1024)).toFixed(2) : '0.00';
+  dropZoneTitle.textContent = file.name;
+  dropZoneSubtitle.textContent = `${sizeMb} MB • ${file.type || 'application/octet-stream'}`;
+}
+
+function setLoading(isLoading) {
+  if (isLoading) {
+    loadingState.classList.remove('hidden');
+    resultsSection.classList.add('hidden');
+    errorBanner.classList.add('hidden');
+    disableDownload();
+  } else {
+    loadingState.classList.add('hidden');
+  }
+}
+
+function setError(message) {
+  if (message) {
+    errorBanner.textContent = message;
+    errorBanner.classList.remove('hidden');
+  } else {
+    errorBanner.textContent = '';
+    errorBanner.classList.add('hidden');
+  }
+}
+
+function clearTable() {
+  lineItemsBody.innerHTML = '';
+}
+
+function clearReview() {
+  reviewList.innerHTML = '';
+}
+
+function renderLineItems(items) {
+  clearTable();
+  if (!items.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 8;
+    cell.className = 'px-5 py-5 text-center text-sm text-slate-300';
+    cell.textContent = 'No line items were generated for the selected trade.';
+    row.appendChild(cell);
+    lineItemsBody.appendChild(row);
+    return;
+  }
+
+  items.forEach((item) => {
+    const row = document.createElement('tr');
+    row.className = 'hover:bg-slate-800/40 transition';
+
+    const cells = [
+      { value: item.description, align: 'text-left' },
+      { value: formatNumber(item.quantity, 2), align: 'text-right' },
+      { value: item.unit, align: 'text-right' },
+      { value: formatCurrency(item.material_unit_cost), align: 'text-right' },
+      { value: formatCurrency(item.material_cost), align: 'text-right' },
+      { value: formatNumber(item.labor_hours, 2), align: 'text-right' },
+      { value: formatCurrency(item.labor_rate_per_hour), align: 'text-right' },
+      { value: formatCurrency(item.labor_cost), align: 'text-right' },
+    ];
+
+    cells.forEach(({ value, align }) => {
+      const cell = document.createElement('td');
+      cell.className = `${align} px-5 py-4 text-sm text-slate-200`;
+      cell.textContent = value;
+      row.appendChild(cell);
+    });
+
+    lineItemsBody.appendChild(row);
+  });
+}
+
+function renderReview(items) {
+  clearReview();
+  if (!items.length) {
+    reviewEmpty.classList.remove('hidden');
+    return;
+  }
+
+  reviewEmpty.classList.add('hidden');
+
+  const severityStyles = {
+    info: 'border-sky-400/30 bg-sky-500/10 text-sky-100',
+    warning: 'border-amber-400/30 bg-amber-500/10 text-amber-100',
+    critical: 'border-rose-400/30 bg-rose-500/10 text-rose-100',
+  };
+
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.className = `rounded-2xl border px-4 py-3 text-sm ${severityStyles[item.severity] || severityStyles.info}`;
+
+    const title = document.createElement('div');
+    title.className = 'flex items-center gap-2 font-semibold';
+    title.innerHTML = `<span class="inline-flex h-2.5 w-2.5 rounded-full bg-current"></span>${item.severity.toUpperCase()}`;
+
+    const message = document.createElement('p');
+    message.className = 'mt-1 leading-relaxed';
+    message.textContent = item.message;
+
+    li.appendChild(title);
+    li.appendChild(message);
+    reviewList.appendChild(li);
+  });
+}
+
+function renderResults(data) {
+  summaryMaterial.textContent = formatCurrency(data.metrics.material_cost);
+  summaryLabor.textContent = formatCurrency(data.metrics.labor_cost);
+  summaryTotal.textContent = formatCurrency(data.metrics.total_cost);
+  summaryHours.textContent = formatNumber(data.metrics.labor_hours, 2);
+
+  heroMaterial.textContent = formatCurrency(data.metrics.material_cost);
+  heroLabor.textContent = formatCurrency(data.metrics.labor_cost);
+  heroTotal.textContent = formatCurrency(data.metrics.total_cost);
+  heroReview.textContent = data.review_summary;
+
+  metaDrawings.textContent = `${data.drawing_count} ${data.drawing_count === 1 ? 'drawing' : 'drawings'}`;
+  metaElements.textContent = `${data.element_count} ${data.element_count === 1 ? 'element' : 'elements'}`;
+  metaLines.textContent = `${data.line_item_count} ${data.line_item_count === 1 ? 'line item' : 'line items'}`;
+
+  renderLineItems(data.line_items);
+  renderReview(data.review);
+
+  enableDownload(data.csv, data.trade_label);
+
+  resultsSection.classList.remove('hidden');
+}
+
+function validateForm() {
+  if (!tradeSelect.value) {
+    throw new Error('Select a trade before running the takeoff.');
+  }
+  if (!fileInput.files || !fileInput.files.length) {
+    throw new Error('Upload a drawing export to continue.');
+  }
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  try {
+    validateForm();
+  } catch (error) {
+    setError(error.message);
+    return;
+  }
+
+  setLoading(true);
+  setError('');
+
+  const formData = new FormData();
+  formData.append('trade', tradeSelect.value);
+  formData.append('drawing', fileInput.files[0]);
+
+  try {
+    const response = await fetch('/api/takeoff', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      let message = 'Failed to run takeoff. Please try again.';
+      try {
+        const payload = await response.json();
+        message = payload.detail || message;
+      } catch (err) {
+        // ignore
+      }
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    renderResults(data);
+    setError('');
+  } catch (error) {
+    setError(error.message || 'Unexpected error.');
+    disableDownload();
+  } finally {
+    setLoading(false);
+  }
+});
+
+fileInput.addEventListener('change', (event) => {
+  const file = event.target.files[0];
+  updateDropzone(file);
+});
+
+dropZone.addEventListener('click', () => {
+  fileInput.click();
+});
+
+dropZone.addEventListener('dragover', (event) => {
+  event.preventDefault();
+  dropZone.classList.add('border-sky-400', 'bg-slate-900/80');
+});
+
+dropZone.addEventListener('dragleave', () => {
+  dropZone.classList.remove('border-sky-400', 'bg-slate-900/80');
+});
+
+dropZone.addEventListener('drop', (event) => {
+  event.preventDefault();
+  dropZone.classList.remove('border-sky-400', 'bg-slate-900/80');
+  const [file] = event.dataTransfer.files;
+  if (!file) {
+    return;
+  }
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  fileInput.files = dataTransfer.files;
+  updateDropzone(file);
+});
+
+resetDropzone();

--- a/construction_takeoff/takeoff/webapp/templates/index.html
+++ b/construction_takeoff/takeoff/webapp/templates/index.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Construction Takeoff Assistant</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      html,
+      body {
+        font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top, #0f172a, #020617 55%);
+      }
+      .glass {
+        backdrop-filter: blur(18px);
+        background: linear-gradient(135deg, rgba(15,23,42,0.8), rgba(30,41,59,0.6));
+        border: 1px solid rgba(148,163,184,0.12);
+      }
+      .sparkle {
+        position: relative;
+        isolation: isolate;
+      }
+      .sparkle::before {
+        content: '';
+        position: absolute;
+        inset: -120px;
+        background: radial-gradient(circle at top right, rgba(56,189,248,0.35), transparent 45%),
+          radial-gradient(circle at bottom left, rgba(216,180,254,0.25), transparent 55%);
+        filter: blur(40px);
+        z-index: -1;
+        opacity: 0.9;
+      }
+    </style>
+  </head>
+  <body class="min-h-full text-slate-100">
+    <div class="relative overflow-hidden">
+      <header class="pt-16 pb-12 sm:pt-24">
+        <div class="mx-auto max-w-6xl px-4">
+          <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
+            <div class="space-y-8">
+              <span class="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-4 py-1 text-sm font-semibold text-sky-200">
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                </svg>
+                Automated takeoffs, human insight ready
+              </span>
+              <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                Transform drawings into actionable estimates in minutes.
+              </h1>
+              <p class="text-lg leading-relaxed text-slate-300">
+                Upload drawing exports, pick your trade, and let the assistant crunch quantities,
+                materials, and labor with transparent checkpoints for human review.
+              </p>
+              <div class="flex flex-wrap gap-4">
+                <a href="#workspace" class="inline-flex items-center rounded-full bg-sky-500 px-6 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400">
+                  Launch workspace
+                  <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 12h13.5m0 0-4.5-4.5m4.5 4.5-4.5 4.5" />
+                  </svg>
+                </a>
+                <a
+                  href="https://github.com/twostraws/HackingWithSwift/tree/main/construction_takeoff"
+                  class="inline-flex items-center gap-2 rounded-full border border-slate-600/60 bg-white/5 px-6 py-3 text-base font-semibold text-slate-200 transition hover:border-slate-400/80 hover:text-white"
+                >
+                  View docs
+                </a>
+              </div>
+              <dl class="mt-8 grid grid-cols-2 gap-6 text-sm text-slate-300 sm:flex sm:gap-10">
+                <div>
+                  <dt class="font-semibold text-slate-200">Supported trades</dt>
+                  <dd id="trade-count">{{ trades | length }}</dd>
+                </div>
+                <div>
+                  <dt class="font-semibold text-slate-200">Human-in-the-loop checkpoints</dt>
+                  <dd>Built-in</dd>
+                </div>
+                <div>
+                  <dt class="font-semibold text-slate-200">Export format</dt>
+                  <dd>Spreadsheet-ready CSV</dd>
+                </div>
+                <div>
+                  <dt class="font-semibold text-slate-200">UX designed for</dt>
+                  <dd>Estimators &amp; project teams</dd>
+                </div>
+              </dl>
+            </div>
+            <div class="sparkle">
+              <div class="glass rounded-3xl p-8 shadow-2xl shadow-sky-900/60">
+                <div class="flex items-center justify-between">
+                  <h2 class="text-xl font-semibold text-white">Live takeoff preview</h2>
+                  <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200">
+                    Real-time
+                  </span>
+                </div>
+                <div class="mt-8 space-y-6">
+                  <div class="grid grid-cols-3 gap-4">
+                    <div class="rounded-2xl border border-sky-300/10 bg-sky-300/5 p-4">
+                      <p class="text-xs uppercase tracking-wide text-slate-300">Material</p>
+                      <p class="mt-2 text-2xl font-semibold text-sky-200" id="hero-material-cost">$0</p>
+                    </div>
+                    <div class="rounded-2xl border border-emerald-300/10 bg-emerald-300/5 p-4">
+                      <p class="text-xs uppercase tracking-wide text-slate-300">Labor</p>
+                      <p class="mt-2 text-2xl font-semibold text-emerald-200" id="hero-labor-cost">$0</p>
+                    </div>
+                    <div class="rounded-2xl border border-fuchsia-300/10 bg-fuchsia-300/5 p-4">
+                      <p class="text-xs uppercase tracking-wide text-slate-300">Total</p>
+                      <p class="mt-2 text-2xl font-semibold text-fuchsia-200" id="hero-total-cost">$0</p>
+                    </div>
+                  </div>
+                  <div>
+                    <p class="text-sm text-slate-300">Latest review summary</p>
+                    <p class="mt-2 rounded-xl border border-white/5 bg-white/5 p-4 text-sm text-slate-200" id="hero-review-summary">
+                      Upload drawings to generate insights instantly.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main id="workspace" class="pb-24">
+        <div class="mx-auto max-w-6xl px-4">
+          <div class="glass rounded-3xl p-10 shadow-xl">
+            <div class="flex flex-col gap-6 lg:flex-row lg:items-start">
+              <section class="lg:w-1/3">
+                <h2 class="text-2xl font-semibold text-white">Upload workspace</h2>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">
+                  Choose the subcontracting trade, drop in your JSON or ZIP export, and the assistant will
+                  orchestrate quantity takeoffs, costing, and review items automatically.
+                </p>
+                <ul class="mt-6 space-y-3 text-sm text-slate-300">
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-sky-500/20 text-sky-300">1</span>
+                    <span>Select trade and drawing export.</span>
+                  </li>
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-sky-500/20 text-sky-300">2</span>
+                    <span>Review the generated line items and human checkpoints.</span>
+                  </li>
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-sky-500/20 text-sky-300">3</span>
+                    <span>Download the spreadsheet-ready CSV for your estimate log.</span>
+                  </li>
+                </ul>
+              </section>
+              <section class="lg:w-2/3">
+                <form id="takeoff-form" class="space-y-6" autocomplete="off">
+                  <div>
+                    <label for="trade" class="block text-sm font-medium text-slate-200">Trade</label>
+                    <select
+                      id="trade"
+                      name="trade"
+                      class="mt-2 block w-full rounded-2xl border-0 bg-slate-900/60 px-4 py-3 text-sm text-slate-100 shadow-inner shadow-black/40 focus:border-sky-400 focus:ring-2 focus:ring-sky-500/60"
+                      required
+                    >
+                      <option value="" disabled selected>Select a trade</option>
+                      {% for trade in trades %}
+                      <option value="{{ trade }}">{{ trade.replace('_', ' ').title() }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                  <div>
+                    <label class="block text-sm font-medium text-slate-200">Drawing export</label>
+                    <div
+                      id="drop-zone"
+                      class="mt-2 flex min-h-[180px] cursor-pointer flex-col items-center justify-center rounded-3xl border border-dashed border-slate-500/60 bg-slate-900/60 p-6 text-center transition hover:border-sky-400/80 hover:bg-slate-900/80"
+                    >
+                      <input id="drawing-file" name="drawing" type="file" accept=".json,.zip" class="hidden" required />
+                      <svg class="h-12 w-12 text-slate-400" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 16.5V9m0 0-3 3m3-3 3 3m6 3.75A2.25 2.25 0 0016.75 18h-9.5A2.25 2.25 0 005 15.75v-7.5A2.25 2.25 0 007.25 6h4.443a2.25 2.25 0 011.59.659l3.557 3.557a2.25 2.25 0 01.66 1.59V15" />
+                      </svg>
+                      <p class="mt-4 text-base font-semibold text-white" id="drop-zone-title">Drag &amp; drop files here</p>
+                      <p class="mt-1 text-sm text-slate-300" id="drop-zone-subtitle">JSON or ZIP exports up to 25MB.</p>
+                      <p class="mt-4 text-xs text-slate-400">Need sample data? Use the <code>docs/sample_drawing.json</code> file included with the project.</p>
+                    </div>
+                  </div>
+                  <div class="flex flex-wrap items-center gap-4">
+                    <button
+                      type="submit"
+                      class="inline-flex items-center gap-2 rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400"
+                    >
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                      </svg>
+                      Run takeoff
+                    </button>
+                    <a
+                      id="download-btn"
+                      href="#"
+                      class="inline-flex items-center gap-2 rounded-full border border-slate-600/60 bg-white/5 px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-slate-400/80 hover:text-white disabled:pointer-events-none disabled:opacity-40"
+                      download="estimate.csv"
+                    >
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M7.5 10.5L12 15m0 0l4.5-4.5M12 15V3" />
+                      </svg>
+                      Download CSV
+                    </a>
+                  </div>
+                  <p id="error-banner" class="hidden rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100"></p>
+                </form>
+              </section>
+            </div>
+
+            <div class="mt-12 border-t border-white/5 pt-10">
+              <div id="loading-state" class="hidden items-center gap-3 rounded-2xl border border-slate-600/50 bg-slate-900/60 px-4 py-3 text-sm text-slate-200">
+                <svg class="h-5 w-5 animate-spin text-sky-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v3m6.364.636l-2.121 2.121M21 12h-3m-.636 6.364l-2.121-2.121M12 21v-3m-6.364.636l2.121-2.121M3 12h3m.636-6.364l2.121 2.121" />
+                </svg>
+                Processing takeoff… This usually takes a few seconds.
+              </div>
+
+              <div id="results" class="hidden space-y-10">
+                <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                  <div class="rounded-2xl border border-sky-300/20 bg-sky-300/10 p-5">
+                    <p class="text-xs uppercase tracking-wide text-sky-100">Material cost</p>
+                    <p class="mt-2 text-3xl font-semibold text-sky-50" id="summary-material-cost">$0</p>
+                  </div>
+                  <div class="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-5">
+                    <p class="text-xs uppercase tracking-wide text-emerald-100">Labor cost</p>
+                    <p class="mt-2 text-3xl font-semibold text-emerald-50" id="summary-labor-cost">$0</p>
+                  </div>
+                  <div class="rounded-2xl border border-fuchsia-300/20 bg-fuchsia-300/10 p-5">
+                    <p class="text-xs uppercase tracking-wide text-fuchsia-100">Total cost</p>
+                    <p class="mt-2 text-3xl font-semibold text-fuchsia-50" id="summary-total-cost">$0</p>
+                  </div>
+                  <div class="rounded-2xl border border-amber-300/20 bg-amber-300/10 p-5">
+                    <p class="text-xs uppercase tracking-wide text-amber-100">Labor hours</p>
+                    <p class="mt-2 text-3xl font-semibold text-amber-50" id="summary-labor-hours">0</p>
+                  </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
+                  <section class="rounded-3xl border border-white/5 bg-slate-900/60 p-6">
+                    <div class="flex flex-wrap items-center justify-between gap-4">
+                      <div>
+                        <h3 class="text-xl font-semibold text-white">Line items</h3>
+                        <p class="text-sm text-slate-300">Structured estimate ready for spreadsheets.</p>
+                      </div>
+                      <div class="flex gap-4 text-xs text-slate-300">
+                        <span class="inline-flex items-center gap-1 rounded-full border border-slate-600/60 px-3 py-1">
+                          <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                          <span id="meta-drawings">0 drawings</span>
+                        </span>
+                        <span class="inline-flex items-center gap-1 rounded-full border border-slate-600/60 px-3 py-1">
+                          <span class="h-2 w-2 rounded-full bg-sky-400"></span>
+                          <span id="meta-elements">0 elements</span>
+                        </span>
+                        <span class="inline-flex items-center gap-1 rounded-full border border-slate-600/60 px-3 py-1">
+                          <span class="h-2 w-2 rounded-full bg-fuchsia-400"></span>
+                          <span id="meta-lines">0 line items</span>
+                        </span>
+                      </div>
+                    </div>
+                    <div class="mt-6 overflow-hidden rounded-2xl border border-white/5">
+                      <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-white/5 text-sm">
+                          <thead class="bg-slate-900/70 text-left text-xs uppercase tracking-wide text-slate-300">
+                            <tr>
+                              <th scope="col" class="px-5 py-3">Description</th>
+                              <th scope="col" class="px-5 py-3">Quantity</th>
+                              <th scope="col" class="px-5 py-3">Unit</th>
+                              <th scope="col" class="px-5 py-3">Material $/unit</th>
+                              <th scope="col" class="px-5 py-3">Material cost</th>
+                              <th scope="col" class="px-5 py-3">Labor hours</th>
+                              <th scope="col" class="px-5 py-3">Labor $/hr</th>
+                              <th scope="col" class="px-5 py-3">Labor cost</th>
+                            </tr>
+                          </thead>
+                          <tbody id="line-items" class="divide-y divide-white/5 bg-slate-900/40"></tbody>
+                        </table>
+                      </div>
+                    </div>
+                  </section>
+
+                  <section class="flex flex-col gap-6">
+                    <div class="rounded-3xl border border-white/5 bg-slate-900/60 p-6">
+                      <h3 class="text-xl font-semibold text-white">Review focus</h3>
+                      <p class="mt-2 text-sm text-slate-300">
+                        These checkpoints highlight assumptions and required confirmations before issuing the estimate.
+                      </p>
+                      <ul id="review-items" class="mt-5 space-y-4"></ul>
+                      <p id="review-empty" class="mt-5 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+                        No human review items. You're clear to proceed!
+                      </p>
+                    </div>
+                    <div class="rounded-3xl border border-white/5 bg-gradient-to-br from-sky-500/10 to-fuchsia-500/10 p-6 text-sm text-slate-200">
+                      <h3 class="text-lg font-semibold text-white">Workflow tips</h3>
+                      <ul class="mt-3 list-disc space-y-2 pl-5">
+                        <li>Drop multiple drawing JSON files in a ZIP to keep related floors together.</li>
+                        <li>Iterate quickly by tweaking pricing or production rates in the trade estimator modules.</li>
+                        <li>Export the CSV directly into your estimating workbook and link to live dashboards.</li>
+                      </ul>
+                    </div>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+    <script src="/static/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared `run_trade_takeoff` service that powers both the CLI and UI flows
- enhance the spreadsheet exporter with in-memory CSV rendering support
- build a FastAPI-driven web experience with Tailwind styling, drag-and-drop uploads, dashboards, and CSV download
- document the UI workflow and dependencies in the README

## Testing
- PYTHONPATH=construction_takeoff python -m takeoff.cli --trade concrete --input construction_takeoff/docs --output /tmp/estimate.csv

------
https://chatgpt.com/codex/tasks/task_e_68e594574450832a9ae86b29b4124fbe